### PR TITLE
feat: allow cookie name to be overriden

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-      - provider
+      - cookie
 
 jobs:
   test:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches-ignore:
       - main
-      - provider
+      - cookie
 
 jobs:
   test:

--- a/README.md
+++ b/README.md
@@ -102,8 +102,8 @@ This created a new middleware `traefik-simple-auth` that forwards incoming reque
 #### Ingress
 
 To authenticate a user, traefik-simple-auth redirects the user to the auth provider's login page. Upon successful login,
-the provider forwards the request to the redirectURL (as configured in section Google). You therefore need an ingress to route 
-the request to traefik-simple-auth:
+the provider forwards the request to the redirectURL (as configured in section `Using Google as auth provider`). 
+You therefore need an ingress to route the request to traefik-simple-auth:
 
 ```
 apiVersion: networking.k8s.io/v1
@@ -127,7 +127,7 @@ spec:
                   number: 8080
 ```
 
-This forwards the request request back to traefik-simple-auth. 
+This forwards the request to traefik-simple-auth. 
 
 ### Running traefik-simple-auth
 
@@ -157,20 +157,25 @@ Usage:
         The OAuth2 provider to use (default "google")
   -secret string
         Secret to use for authentication
+  -session-cookie-name string
+        The cookie name to use for authentication (default "traefik-simple-auth")
   -users string
         Comma-separated list of usernames to login
-
 ```
 
 #### Option details
+
+- `debug`
+
+  Enable debug mode
 
 - `addr`
 
   Listener address for traefik-simple-auth
 
-- `auth-prefix`
+- `prom`
 
-   Prefix used to construct the authorization URL from the domain.
+  Listener address for Prometheus metrics
 
 - `provider`
 
@@ -178,19 +183,27 @@ Usage:
 
 - `client-id`
 
-  The (hex-encoded) Google Client ID, found in the Google Credentials configuration.
+  The Client ID, found in the OAuth provider's credentials configuration.
 
 - `client-secret`
 
-  The (hex-encoded) Google Client Secret, found in the Google Credentials configuration
+  The Client Secret, found in the OAuth provider's Credentials configuration.
 
-- `debug`
+- `auth-prefix`
 
-  Enable debug mode
+  Prefix used to construct the authorization URL from the domain.
+
+- `session-cookie-name`
+
+  The name of the browser cookie holding the session. Overriding this may be useful when you to segregate a user signing into one instance of traefik-simple-auth vs. any other instances.
+  
+  By default, traefik-simple-auth uses Google as oauth provider and a session cooke called `traefik-simple-auth`.
+  If a second instance, using GitHub oauth, used the same cookie name, then signing in to Google would also allow any flows
+  authenticated by GitHub. If you want to segregate this, use a different `session-cookie-name` for the GitHub instance.  
 
 - `domains`
 
-   A comma-separared list of all domains that should be allowed. If "example.com" is an allowed domain, then all subdomains (eg. www.example.com) will be allowed.
+   A comma-separated list of all domains that should be allowed. If "example.com" is an allowed domain, then all subdomains (eg. www.example.com) are allowed.
 
 - `expiry`
 
@@ -199,10 +212,6 @@ Usage:
 - `insecure`
 
   Marks the session cookie as insecure so it can be used over HTTP sessions.
-
-- `prom`
-
-  Listener address for Prometheus metrics
 
 - `secret`
 

--- a/cmd/traefik-simple-auth/traefik-simple-auth.go
+++ b/cmd/traefik-simple-auth/traefik-simple-auth.go
@@ -20,7 +20,7 @@ var (
 	debug             = flag.Bool("debug", false, "Enable debug mode")
 	addr              = flag.String("addr", ":8080", "The address to listen on for HTTP requests")
 	promAddr          = flag.String("prom", ":9090", "The address to listen on for Prometheus scrape requests")
-	sessionCookieName = flag.String("session-cookie-name", "traefik_simple_auth", "The cookie name to use for authentication")
+	sessionCookieName = flag.String("session-cookie-name", "_traefik_simple_auth", "The cookie name to use for authentication")
 	expiry            = flag.Duration("expiry", 30*24*time.Hour, "How long a session remains valid")
 	insecure          = flag.Bool("insecure", false, "Use insecure cookies")
 	authPrefix        = flag.String("auth-prefix", "auth", "prefix to construct the authRedirect URL from the domain")

--- a/cmd/traefik-simple-auth/traefik-simple-auth.go
+++ b/cmd/traefik-simple-auth/traefik-simple-auth.go
@@ -20,7 +20,7 @@ var (
 	debug             = flag.Bool("debug", false, "Enable debug mode")
 	addr              = flag.String("addr", ":8080", "The address to listen on for HTTP requests")
 	promAddr          = flag.String("prom", ":9090", "The address to listen on for Prometheus scrape requests")
-	sessionCookieName = flag.String("session-cookie-name", "traefik-simple-auth", "The cookie name to use for authentication")
+	sessionCookieName = flag.String("session-cookie-name", "traefik_simple_auth", "The cookie name to use for authentication")
 	expiry            = flag.Duration("expiry", 30*24*time.Hour, "How long a session remains valid")
 	insecure          = flag.Bool("insecure", false, "Use insecure cookies")
 	authPrefix        = flag.String("auth-prefix", "auth", "prefix to construct the authRedirect URL from the domain")

--- a/cmd/traefik-simple-auth/traefik-simple-auth.go
+++ b/cmd/traefik-simple-auth/traefik-simple-auth.go
@@ -17,18 +17,19 @@ import (
 )
 
 var (
-	debug        = flag.Bool("debug", false, "Enable debug mode")
-	addr         = flag.String("addr", ":8080", "The address to listen on for HTTP requests")
-	promAddr     = flag.String("prom", ":9090", "The address to listen on for Prometheus scrape requests")
-	expiry       = flag.Duration("expiry", 30*24*time.Hour, "How long a session remains valid")
-	insecure     = flag.Bool("insecure", false, "Use insecure cookies")
-	authPrefix   = flag.String("auth-prefix", "auth", "prefix to construct the authRedirect URL from the domain")
-	domains      = flag.String("domains", "", "Comma-separated list of domains to allow access")
-	users        = flag.String("users", "", "Comma-separated list of usernames to login")
-	provider     = flag.String("provider", "google", "The OAuth2 provider to use")
-	clientId     = flag.String("client-id", "", "OAuth2 Client ID")
-	clientSecret = flag.String("client-secret", "", "OAuth2 Client Secret")
-	secret       = flag.String("secret", "", "Secret to use for authentication")
+	debug             = flag.Bool("debug", false, "Enable debug mode")
+	addr              = flag.String("addr", ":8080", "The address to listen on for HTTP requests")
+	promAddr          = flag.String("prom", ":9090", "The address to listen on for Prometheus scrape requests")
+	sessionCookieName = flag.String("session-cookie-name", "traefik-simple-auth", "The cookie name to use for authentication")
+	expiry            = flag.Duration("expiry", 30*24*time.Hour, "How long a session remains valid")
+	insecure          = flag.Bool("insecure", false, "Use insecure cookies")
+	authPrefix        = flag.String("auth-prefix", "auth", "prefix to construct the authRedirect URL from the domain")
+	domains           = flag.String("domains", "", "Comma-separated list of domains to allow access")
+	users             = flag.String("users", "", "Comma-separated list of usernames to login")
+	provider          = flag.String("provider", "google", "The OAuth2 provider to use")
+	clientId          = flag.String("client-id", "", "OAuth2 Client ID")
+	clientSecret      = flag.String("client-secret", "", "OAuth2 Client Secret")
+	secret            = flag.String("secret", "", "Secret to use for authentication")
 
 	version string = "change-me"
 )
@@ -71,14 +72,15 @@ func getConfiguration(l *slog.Logger) server.Config {
 		os.Exit(1)
 	}
 	return server.Config{
-		Expiry:         *expiry,
-		Secret:         secretBytes,
-		InsecureCookie: *insecure,
-		Domains:        strings.Split(*domains, ","),
-		Users:          strings.Split(*users, ","),
-		Provider:       *provider,
-		ClientID:       *clientId,
-		ClientSecret:   *clientSecret,
-		AuthPrefix:     *authPrefix,
+		SessionCookieName: *sessionCookieName,
+		Expiry:            *expiry,
+		Secret:            secretBytes,
+		InsecureCookie:    *insecure,
+		Domains:           strings.Split(*domains, ","),
+		Users:             strings.Split(*users, ","),
+		Provider:          *provider,
+		ClientID:          *clientId,
+		ClientSecret:      *clientSecret,
+		AuthPrefix:        *authPrefix,
 	}
 }

--- a/internal/server/logged-request.go
+++ b/internal/server/logged-request.go
@@ -3,7 +3,6 @@ package server
 import (
 	"log/slog"
 	"net/http"
-	"strings"
 )
 
 var _ slog.LogValuer = loggedRequest{}
@@ -11,15 +10,8 @@ var _ slog.LogValuer = loggedRequest{}
 type loggedRequest struct{ r *http.Request }
 
 func (r loggedRequest) LogValue() slog.Value {
-	cookies := make([]string, 0, 1)
-	for _, c := range r.r.Cookies() {
-		if c.Name == sessionCookieName {
-			cookies = append(cookies, c.Name)
-		}
-	}
 	return slog.GroupValue(
 		slog.String("http", r.r.URL.String()),
-		slog.String("sessions", strings.Join(cookies, ",")),
 		slog.String("source", r.r.Header.Get("X-Forwarded-For")),
 	)
 }

--- a/internal/server/logged-request_test.go
+++ b/internal/server/logged-request_test.go
@@ -11,14 +11,13 @@ import (
 
 func Test_loggedRequest(t *testing.T) {
 	r := makeHTTPRequest(http.MethodGet, "example.com", "/foo/bar")
-	r.AddCookie(&http.Cookie{Name: sessionCookieName, Value: "foo"})
 	r.Header.Add("X-Forwarded-For", "127.0.0.1:0")
 
 	var out bytes.Buffer
 	l := testutils.NewJSONLogger(&out, slog.LevelInfo)
 	l.Info("request", "r", loggedRequest{r: r})
 
-	want := `{"level":"INFO","msg":"request","r":{"http":"https://traefik/","sessions":"_traefik_simple_auth","source":"127.0.0.1:0"}}
+	want := `{"level":"INFO","msg":"request","r":{"http":"https://traefik/","source":"127.0.0.1:0"}}
 `
 	assert.Equal(t, want, out.String())
 }

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -80,11 +80,12 @@ func TestServer_authHandler(t *testing.T) {
 	}
 
 	config := Config{
-		Domains:  Domains{"example.com"},
-		Secret:   []byte("secret"),
-		Expiry:   time.Hour,
-		Users:    []string{"foo@example.com"},
-		Provider: "google",
+		SessionCookieName: "_traefik_simple_auth",
+		Domains:           Domains{"example.com"},
+		Secret:            []byte("secret"),
+		Expiry:            time.Hour,
+		Users:             []string{"foo@example.com"},
+		Provider:          "google",
 	}
 	s := New(config, slog.Default())
 
@@ -221,10 +222,11 @@ func TestServer_redirectToAuth(t *testing.T) {
 
 func TestServer_LogoutHandler(t *testing.T) {
 	config := Config{
-		Secret:   []byte("secret"),
-		Domains:  Domains{"example.com"},
-		Expiry:   time.Hour,
-		Provider: "google",
+		SessionCookieName: "_traefik_simple_auth",
+		Secret:            []byte("secret"),
+		Domains:           Domains{"example.com"},
+		Expiry:            time.Hour,
+		Provider:          "google",
 	}
 	s := New(config, slog.New(slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug})))
 

--- a/internal/server/session-cookie.go
+++ b/internal/server/session-cookie.go
@@ -12,8 +12,6 @@ import (
 	"time"
 )
 
-const sessionCookieName = "_traefik_simple_auth"
-
 var (
 	errCookieInvalidMAC       = errors.New("cookie has invalid MAC")
 	errCookieInvalidStructure = errors.New("cookie has invalid structure")

--- a/internal/server/session-cookie_test.go
+++ b/internal/server/session-cookie_test.go
@@ -106,13 +106,13 @@ func TestSessionCookieHandler_getSessionCookie(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			p := sessionCookieHandler{
+			handler := sessionCookieHandler{
 				SecureCookie: true,
 				Secret:       secret,
 				sessions:     cache.New[string, sessionCookie](time.Hour, time.Minute),
 			}
 
-			_, err := p.getSessionCookie(&http.Cookie{Name: sessionCookieName, Value: tt.value})
+			_, err := handler.getSessionCookie(&http.Cookie{Value: tt.value})
 			assert.ErrorIs(t, err, tt.wantErr)
 		})
 	}


### PR DESCRIPTION
Useful when running multiple traefik-simple-auth instances and you want to segregate access (i.e. logging into one traefik-simple-auth doesn't also log in for any other instance)